### PR TITLE
Add Employee Repository

### DIFF
--- a/ems-back-end/src/main/java/com/sethu/ems/repository/EmployeeRepository.java
+++ b/ems-back-end/src/main/java/com/sethu/ems/repository/EmployeeRepository.java
@@ -1,0 +1,7 @@
+package com.sethu.ems.repository;
+
+import com.sethu.ems.entity.Employee;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface EmployeeRepository  extends JpaRepository<Employee, Long> {
+}


### PR DESCRIPTION
Employee Repository will assist this application to interact with the database:

#NB
JpaRepository interface in Spring Data JPA already extends CrudRepository, which is annotated with @Repository. JpaRepository methods are transactional by default, so you don't need to annotate it with @Transactional.